### PR TITLE
add more environment variables via profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 /composer.lock
 /vendor/
 *.phar

--- a/src/StackFormation/Profile/YamlCredentialProvider.php
+++ b/src/StackFormation/Profile/YamlCredentialProvider.php
@@ -64,7 +64,7 @@ class YamlCredentialProvider {
             if(false === (bool)preg_match('/^[a-z0-9-_]+/', $key)){
                 throw new \Exception("Invalid environment variable in profile $profile");
             }else{
-                $envVars[strtoupper(str_replace('-','_',$key))] = $value;
+                $envVars[strtoupper(str_replace('-','_',$key))] = sprintf('"%s"', $value);
             }
         }
         return $envVars;

--- a/src/StackFormation/Profile/YamlCredentialProvider.php
+++ b/src/StackFormation/Profile/YamlCredentialProvider.php
@@ -64,7 +64,7 @@ class YamlCredentialProvider {
             if(false === (bool)preg_match('/^[a-z0-9-_]+/', $key)){
                 throw new \Exception("Invalid environment variable in profile $profile");
             }else{
-                $envVars[strtoupper($key)] = $value;
+                $envVars[strtoupper(str_replace('-','_',$key))] = $value;
             }
         }
         return $envVars;


### PR DESCRIPTION
Developsers are lazy so i added the possibility to define more environment variables via profiles.yml
as example:

```
profiles:
  testing:
    filter: '/^myproject-(a|b)-/'
    environment: 'testing'
    another-environment-key: 'i am lazy'
    region: 'eu-central-1'
    access_key: '******'
    secret_key: '******'
```

will generate an .env file like this. please check the environment variable value for another-environment-key

```
AWS_ACCESS_KEY_ID=******
AWS_SECRET_ACCESS_KEY=******
AWS_DEFAULT_REGION=eu-central-1
STACKFORMATION_NAME_FILTER=/^myproject-(a|b)-/
ENVIRONMENT=testing
ANOTHER_ENVIRONMENT_KEY="i am lazy%"
```
