### PR TITLE
Add blueprint parameters as env variables in before/after scripts

### DIFF
--- a/src/StackFormation/BlueprintAction.php
+++ b/src/StackFormation/BlueprintAction.php
@@ -54,7 +54,9 @@ class BlueprintAction {
         }
 
         if ($this->output && !$this->output->isQuiet()) { $this->output->writeln("Running scripts ($type)"); }
-
+        foreach($this->blueprint->getParameters() as $parameter) {
+            $envVars[] = $parameter['ParameterKey'] . '=' . $parameter['ParameterValue'];
+        }
         $envVars = array_merge([
             "BLUEPRINT=".$this->blueprint->getName(),
             "STACKNAME=".$this->blueprint->getStackName(),


### PR DESCRIPTION
This is exposes parameters to the before/after scripts.

Previously, if you wanted to pass envs, vars, params to a before/after script you need to do something like

```
blueprints:
  - stackname: 'something-lambda'
    template: 'lambda.template'
    Capabilities: 'CAPABILITY_IAM'
    parameters:
      S3Bucket: 'mybucket'
      S3KeyPrefix: 'uploads/functions_{tstamp}/'
    before:
      - 'cd function && ../scripts/zip-and-upload-to-s3.sh s3://{var:S3Bucket}/{var:S3KeyPrefix} {var:SomeOtherVar-{env:Environment}}'
```

Then in your `zip-and-upload-to-s3.sh` script you need to use `$1`, `$2`, etc

```
perl -pi -e "s/{{SomeOtherVar}}/$2/g" "/path/to/function.js"

aws s3 cp --recursive "/path/to/function.js" "$1"
```

This is getting messy when my lambda functions start requiring a lot of blueprint vars, resources, etc.

---

With this PR all blueprint params are added to the environment

```
blueprints:
  - stackname: 'something-lambda'
    template: 'lambda.template'
    Capabilities: 'CAPABILITY_IAM'
    parameters:
      S3Bucket: 'mybucket'
      S3KeyPrefix: 'uploads/functions_{tstamp}/'
      SomeOtherVar: '{var:SomeOtherVar-{env:Environment}}'
    before:
      - 'cd function && ../scripts/zip-and-upload-to-s3.sh'
```

And I can access them in the script like

```
perl -pi -e "s/{{SomeOtherVar}}/$SomeOtherVar/g" "/path/to/function.js"

aws s3 cp --recursive "/path/to/function.js" "s3://$S3Bucket/$S3KeyPrefix"
```

---

This is really handy, for example, when you have a lot of DynamoDB table names that you need to pass to your script.  You can use a function like

```
replaceParametersInFile() {
    while IFS='=' read -r NAME VALUE ; do
        sed -i -- "s~{{$NAME}}~$VALUE~g" "$1"
    done < <(env)
}
```

to replace all `{{PARAM}}` style tags with their values as they're added.